### PR TITLE
Protect against ReadTimeout errors sometimes returned by requests.

### DIFF
--- a/cdsapi/api.py
+++ b/cdsapi/api.py
@@ -360,7 +360,7 @@ class Client(object):
             while tries < self.retry_max:
                 try:
                     r = call(*args, **kwargs)
-                except requests.exceptions.ConnectionError as e:
+                except (requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout) as e:
                     r = None
                     self.warning("Recovering from connection error [%s], attemps %s of %s",
                                  e, tries, self.retry_max)


### PR DESCRIPTION
Just a very simple fix, sometimes I observe that requests return a ReadTimeout error, and it would be nice if this was retried like other transient errors.
