### PR TITLE
workflow_name parameter can now be supplied when calling

### DIFF
--- a/cdsapi/api.py
+++ b/cdsapi/api.py
@@ -319,11 +319,11 @@ class Client(object):
         result = self._api('%s/tasks/services/%s/clientid-%s' % (self.url, name, uuid.uuid4().hex), request, 'PUT')
         return result
 
-    def workflow(self, code, *args, **kwargs):
+    def workflow(self, code, *args,  workflow_name='application', **kwargs):
         params = dict(code=code,
                       args=args,
                       kwargs=kwargs,
-                      workflow_name='application')
+                      workflow_name=workflow_name)
         return self.service("tool.toolbox.orchestrator.run_workflow", params)
 
     def status(self, context=None):


### PR DESCRIPTION
workflow_name parameter can now be supplied when calling 
cdsapi.workflow. This parameter must match with the name of the main function inside the workflow. Default behaviour is kept the same: assuming that workflow_name is "application". This change is implemented in order to be able to run the example workflows automatically with the cdsapi.