### PR TITLE
Add one argument (allowing for usage of specified web client)

### DIFF
--- a/cdsapi/api.py
+++ b/cdsapi/api.py
@@ -109,7 +109,7 @@ class Result(object):
 
         while tries < self.retry_max:
 
-            r = self.robust(requests.get)(url,
+            r = self.robust(self.session.get)(url,
                                           stream=True,
                                           verify=self.verify,
                                           headers=headers,
@@ -255,6 +255,7 @@ class Client(object):
                  debug_callback=None,
                  metadata=None,
                  forget=False,
+                 session=requests.Session()
                  ):
 
         if not quiet:
@@ -305,7 +306,7 @@ class Client(object):
         self.info_callback = info_callback
         self.error_callback = error_callback
 
-        self.session = requests.Session()
+        self.session = session
         self.session.auth = tuple(self.key.split(':', 2))
 
         self.metadata = metadata
@@ -350,7 +351,7 @@ class Client(object):
 
     def status(self, context=None):
         url = '%s/status.json' % (self.url,)
-        r = requests.get(url, verify=self.verify)
+        r = self.session.get(url, verify=self.verify)
         r.raise_for_status()
         return r.json()
 


### PR DESCRIPTION
This fork is meant to allow the usage of a particular web client (in my case, I'm using pypac which is based on requests).

It will also allow the usage of proxies (when working in some particular environments as is my case at the office...), basically with 

```
import requests
import cdsapi

s = requests.Session()
s.proxies.update({'http':'mon_ip_proxy'})
c = cdsapi.Client(session=s)
c.retrieve(...)
```