### PR TITLE
Mimic CDS UI requests

### DIFF
--- a/cdsapi/api.py
+++ b/cdsapi/api.py
@@ -332,10 +332,16 @@ class Client(object):
             result.download(target)
         return result
 
-    def service(self, name, *args, **kwargs):
+    def service(self, name, *args, mimic_ui=False, **kwargs):
         self.delete = False  # Don't delete results
         name = '/'.join(name.split('.'))
         request = dict(args=args, kwargs=kwargs)
+        # To mimic the CDS ui the args must included directly at the top level of the request
+        # This is applicable to preloading application workflows 
+        if mimic_ui:
+            request.update(request['args'][0])
+            del request['args']
+
         if self.metadata:
             request['_cds_metadata'] = self.metadata
         request = toJSON(request)


### PR DESCRIPTION
You may have another idea of how to do this, and maybe even change the default cdsapi behaviour.
The important bit is that my change to request means it produces the same requesthash in the brokerdb as an identical call from the CDS UI. This means we don't have to run through all the intermediate steps when an application is preloaded in the backend.