### PR TITLE
mimic CDS UI

### DIFF
--- a/cdsapi/api.py
+++ b/cdsapi/api.py
@@ -332,10 +332,16 @@ class Client(object):
             result.download(target)
         return result
 
-    def service(self, name, *args, **kwargs):
+    def service(self, name, *args, mimic_ui=False, **kwargs):
         self.delete = False  # Don't delete results
         name = '/'.join(name.split('.'))
         request = dict(args=args, kwargs=kwargs)
+        # To mimic the CDS ui the args must included directly at the top level of the request
+        # This is applicable to preloading application workflows 
+        if mimic_ui:
+            request.update(request['args'][0])
+            del request['args']
+
         if self.metadata:
             request['_cds_metadata'] = self.metadata
         request = toJSON(request)

--- a/cdsapi/api.py
+++ b/cdsapi/api.py
@@ -335,12 +335,11 @@ class Client(object):
     def service(self, name, *args, mimic_ui=False, **kwargs):
         self.delete = False  # Don't delete results
         name = '/'.join(name.split('.'))
-        request = dict(args=args, kwargs=kwargs)
-        # To mimic the CDS ui the args must included directly at the top level of the request
-        # This is applicable to preloading application workflows 
+        # To mimic the CDS ui the request should be populated directly with the kwargs
         if mimic_ui:
-            request.update(request['args'][0])
-            del request['args']
+            request = kwargs
+        else:
+            request = dict(args=args, kwargs=kwargs)
 
         if self.metadata:
             request['_cds_metadata'] = self.metadata


### PR DESCRIPTION
This may not be how you want to implement it but this method produces what is sent to the brokerdb by the application CDS-UI.
The key point is that the request should not have keys 'args' and 'kwargs'. This may only work for the run_workflow service.