### PR TITLE
fix ambiguous verify default value

### DIFF
--- a/cdsapi/api.py
+++ b/cdsapi/api.py
@@ -295,7 +295,7 @@ class Client(object):
                     url = config.get("url")
 
                 if verify is None:
-                    verify = int(config.get("verify", 1))
+                    verify = bool(int(config.get("verify", 1)))
 
         if url is None or key is None or key is None:
             raise Exception("Missing/incomplete configuration file: %s" % (dotrc))
@@ -306,7 +306,7 @@ class Client(object):
         self.quiet = quiet
         self.progress = progress and not quiet
 
-        self.verify = True if verify else False
+        self.verify = True if verify is not False else False
         self.timeout = timeout
         self.sleep_max = sleep_max
         self.retry_max = retry_max


### PR DESCRIPTION
The default value of `Client`'s `verify` argument is `None`, which currently resolves to `True` when stuff is load from an rc-file, and to `False` otherwise. Let's be more straight forward and let it always resolve to the same thing, and let's be safe by default.
The problem was intoduced by https://github.com/ecmwf/cdsapi/commit/28ac54c3bdef69fb2c80c6ab56424a7f493f91d5