### PR TITLE
Explicit check for the request parameter type

### DIFF
--- a/cdsapi/api.py
+++ b/cdsapi/api.py
@@ -402,6 +402,9 @@ class Client(object):
 
     def _api(self, url, request, method):
 
+        if not isinstance(request,dict):
+            raise ValueError("Request must be a dictionary, got %s"%(type(request)))
+
         self._status(url)
 
         session = self.session


### PR DESCRIPTION
I had put an extra comma after the request in my code,so the `request` parameter turned into a tuple. 
```
c = cdsapi.Client(url="https://ads.atmosphere.copernicus.eu/api/v2")
req={"model":"chimere","date":"2018-12-31","time":["00:00","01:00"],"format":"netcdf","type":"analysis","variable":"carbon_monoxide","level":0,"leadtime_hour":"0"},
c.retrieve( 'cams-europe-air-quality-forecasts', req, 'out.nc')
```
As a result the code reported "internal server error" and went into a long loop of retries,  complaining that something is wrong with the server.
```
2021-04-22 09:44:10,602 WARNING Not a JSON Object: [{"model":"chimere","date":"2018-12-26","time":["00:00","01:00"],"format":"netcdf","type":"analysis","variable":"carbon_monoxide","level":0,"leadtime_hour":"0"}]
2021-04-22 09:44:10,602 WARNING Recovering from HTTP error [500 ], attemps 0 of 500
```

I consider such a behaviour as buggy: 
- Wrong argument should throw an exception rather than print something to log.
- There is no such object as "JSON Object" in the module. It is dictionary, that should be passed.
- "HTTP error 500" is misleading diagnostics pointing that there is something wrong at the server.
 
The proposed patch causes an exception if anything but a dictionary is fed to the retrieve routine.
I would guess that infinite retry loop and misleading warnings/errors should be fixed as well.

Thank you!
