### PR TITLE
don't use logging.basicConfig

### DIFF
--- a/cdsapi/api.py
+++ b/cdsapi/api.py
@@ -278,11 +278,14 @@ class Client(object):
             else:
                 level = logging.INFO
 
-            formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
             self.logger.setLevel(level)
-            handler = logging.StreamHandler()
-            handler.setFormatter(formatter)
-            self.logger.addHandler(handler)
+
+            # avoid duplicate handlers when creating more than one Client
+            if not self.logger.handlers:
+                formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+                handler = logging.StreamHandler()
+                handler.setFormatter(formatter)
+                self.logger.addHandler(handler)
 
         dotrc = os.environ.get("CDSAPI_RC", os.path.expanduser("~/.cdsapirc"))
 

--- a/cdsapi/api.py
+++ b/cdsapi/api.py
@@ -278,9 +278,11 @@ class Client(object):
             else:
                 level = logging.INFO
 
-            logging.basicConfig(
-                level=level, format="%(asctime)s %(levelname)s %(message)s"
-            )
+            formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+            self.logger.setLevel(level)
+            handler = logging.StreamHandler()
+            handler.setFormatter(formatter)
+            self.logger.addHandler(formatter)
 
         dotrc = os.environ.get("CDSAPI_RC", os.path.expanduser("~/.cdsapirc"))
 

--- a/cdsapi/api.py
+++ b/cdsapi/api.py
@@ -282,7 +282,7 @@ class Client(object):
             self.logger.setLevel(level)
             handler = logging.StreamHandler()
             handler.setFormatter(formatter)
-            self.logger.addHandler(formatter)
+            self.logger.addHandler(handler)
 
         dotrc = os.environ.get("CDSAPI_RC", os.path.expanduser("~/.cdsapirc"))
 


### PR DESCRIPTION
Closes #46.

With this patch, creating a `Client` no longer affects the external loggers' level:

```python
In [1]: import logging
   ...: import cdsapi
   ...:
   ...: # external logger initially at WARNING level:
   ...: my_logger = logging.getLogger('my_logger')
   ...: print(my_logger)  # <Logger my_logger (WARNING)>
   ...: my_logger.info('this is not printed')
   ...: client = cdsapi.Client()
   ...: print(my_logger)  # <Logger my_logger (INFO)>
   ...: my_logger.info('this is printed')
   ...:
<Logger my_logger (WARNING)>
<Logger my_logger (WARNING)>
```

Happy to add tests/docs/etc, let me know if that's needed.