### PR TITLE
Update api.py

### DIFF
--- a/cdsapi/api.py
+++ b/cdsapi/api.py
@@ -254,7 +254,7 @@ class Client(object):
         key=os.environ.get("CDSAPI_KEY"),
         quiet=False,
         debug=False,
-        verify=None,
+        verify=True,
         timeout=60,
         progress=True,
         full_stack=False,


### PR DESCRIPTION
Updated default verify in Client class to True (instead of None)

The line "self.verify = True if verify else False" takes verify, if it is None, the result of this if clause will be False.
Verify false is a bad default, disabling SSL verification as a default is a bad security practice.

