### PR TITLE
Bugfix/timeout and sleep

### DIFF
--- a/cdsapi/api.py
+++ b/cdsapi/api.py
@@ -206,7 +206,8 @@ class Result(object):
         task_url = "%s/tasks/%s" % (self._url, request_id)
         self.debug("GET %s", task_url)
 
-        result = self.robust(self.session.get)(task_url, verify=self.verify)
+        result = self.robust(self.session.get)(task_url, verify=self.verify,
+                                               timeout=self.timeout)
         result.raise_for_status()
         self.reply = result.json()
 
@@ -221,7 +222,8 @@ class Result(object):
             task_url = "%s/tasks/%s" % (self._url, rid)
             self.debug("DELETE %s", task_url)
 
-            delete = self.session.delete(task_url, verify=self.verify)
+            delete = self.session.delete(task_url, verify=self.verify,
+                                         timeout=self.timeout)
             self.debug("DELETE returns %s %s", delete.status_code, delete.reason)
 
             try:


### PR DESCRIPTION
* Add timeout to session.get in Client.status which otherwise hangs on connection error
* Also add timeouts in Result.update and Result.delete which presumably would also hang
* Reorganise Client.robust to avoid an unecessary final sleep after the final try and have it raise an Exception rather than return None, which creates problems elsewhere
