### PR TITLE
Replaced default python-requests user-agent with a custom ones

### DIFF
--- a/cdsapi/api.py
+++ b/cdsapi/api.py
@@ -14,6 +14,7 @@ import os
 import logging
 import uuid
 import requests
+import pkg_resources
 
 try:
     from urllib.parse import urljoin
@@ -322,6 +323,9 @@ class Client(object):
 
         self.session = session
         self.session.auth = tuple(self.key.split(":", 2))
+        self.session.headers = {
+            'User-Agent': 'cdsapi/%s' % pkg_resources.get_distribution('cdsapi').version,
+        }
 
         self.metadata = metadata
         self.forget = forget


### PR DESCRIPTION
Default user-agent sent by cdsapi is inherited from it's dependency python-requests, which is [python-requests/x.y.z](https://github.com/psf/requests/blob/8bce583b9547c7b82d44c8e97f37cf9a16cbe758/requests/utils.py#L860)

So it's not easy to know if the request came from official cdsapi or another Python code script that use python-requests under the hood.

Changing this can improve log analysis and QoS a bit (at least for 99% of users).

HTTP access log will now contains a user-agent field like the following:

```
… "cdsapi/0.5.1"
```
