### PR TITLE
Default verify=True

### DIFF
--- a/cdsapi/api.py
+++ b/cdsapi/api.py
@@ -295,10 +295,14 @@ class Client(object):
                     url = config.get("url")
 
                 if verify is None:
-                    verify = int(config.get("verify", 1))
+                    verify = bool(int(config.get("verify", 1)))
 
         if url is None or key is None or key is None:
             raise Exception("Missing/incomplete configuration file: %s" % (dotrc))
+
+        # If verify is still None, then we set to default value of True
+        if verify is None:
+            verify = True
 
         self.url = url
         self.key = key


### PR DESCRIPTION
This change ensures that the default value for verify is always True.
Without this change the default value changes based on how you provide the CDS-URL and CDS-APIKEY.
This addresses PRs: #39 and #52