### PR TITLE
allow IO objects as file target

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,3 +7,4 @@ pytest-pep8
 pytest-runner
 pytest
 requests
+requests-mock


### PR DESCRIPTION
The library is able to help with downloading data to a local file. Sometimes the target is not local, however. It would be great to allow not only writing to local files, but any IO object, which may represent remote files.

This is basically implemented by adding `io.RawIOBase` and `io.BufferedIOBase` to the allowed target types.