### PR TITLE
Use importlib instead of pkg_resources when possible

### DIFF
--- a/cdsapi/api.py
+++ b/cdsapi/api.py
@@ -14,7 +14,10 @@ import os
 import time
 import uuid
 
-import pkg_resources
+try:
+    from importlib_metadata import distribution as get_distribution
+except ImportError:
+    from pkg_resources import get_distribution
 import requests
 
 try:
@@ -330,8 +333,7 @@ class Client(object):
         self.session = session
         self.session.auth = tuple(self.key.split(":", 2))
         self.session.headers = {
-            "User-Agent": "cdsapi/%s"
-            % pkg_resources.get_distribution("cdsapi").version,
+            "User-Agent": "cdsapi/%s" % get_distribution("cdsapi").version,
         }
 
         assert len(self.session.auth) == 2, (


### PR DESCRIPTION
Use of pkg_resources triggers DeprecationWarning and according to https://setuptools.pypa.io/en/latest/pkg_resources.html, pkg_resources should be replaced by importlib.

Minimal steps to reproduce warning:
- Install pytest
- create a file (let's say 'test.py') with :
`import cdsapi`
- run `pytest test.py`

Pytest should raise following warning:
`warnings.warn("pkg_resources is deprecated as an API", DeprecationWarning)`