### PR TITLE
Allow CI to access secrets once PR is approved

### DIFF
--- a/.github/workflows/check-and-publish.yml
+++ b/.github/workflows/check-and-publish.yml
@@ -2,14 +2,13 @@ name: Check and publish
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
 
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
   release:
     types: [created]
-
 
 jobs:
   quality-checks:
@@ -64,26 +63,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist
-        twine upload dist/*
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist
+          twine upload dist/*
 
-    - name: Notify climetlab
-      uses: mvasigh/dispatch-action@main
-      with:
+      - name: Notify climetlab
+        uses: mvasigh/dispatch-action@main
+        with:
           token: ${{ secrets.NOTIFY_ECMWFLIBS }}
           repo: climetlab
           owner: ecmwf

--- a/.github/workflows/check-and-publish.yml
+++ b/.github/workflows/check-and-publish.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [master]
 
+  # Trigger on public pull request approval
+  pull_request_target:
+    types: [labeled]
+
   release:
     types: [created]
 
@@ -15,7 +19,7 @@ jobs:
     name: Code QA
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: pip install black flake8 isort
       - run: black --version
       - run: isort --version
@@ -26,6 +30,7 @@ jobs:
 
   platform-checks:
     needs: quality-checks
+    if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
     strategy:
       fail-fast: false
       matrix:
@@ -38,7 +43,9 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - uses: actions/setup-python@v2
         with:
@@ -63,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/label-public-pr.yml
+++ b/.github/workflows/label-public-pr.yml
@@ -1,0 +1,10 @@
+# Manage labels of pull requests that originate from forks
+name: label-public-pr
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  label:
+    uses: ecmwf-actions/reusable-workflows/.github/workflows/label-pr.yml@v2


### PR DESCRIPTION
My autoformatter (prettier v2.8.8) was partially unhappy with the existing ci YAML and I didn't see a linter config in the repo so I've added a separate autoformat commit.