### PR TITLE
Fix issue #82

### DIFF
--- a/cdsapi/api.py
+++ b/cdsapi/api.py
@@ -270,6 +270,7 @@ class Client(object):
         forget=False,
         session=requests.Session(),
     ):
+        self.logger.setLevel(logging.NOTSET)
         if not quiet:
             if debug:
                 level = logging.DEBUG


### PR DESCRIPTION
Closes https://github.com/ecmwf/cdsapi/issues/82.

The patch ensures that the logging behavior aligns with the value of the `quiet` parameter, as expected:

```
QUIET: True

QUIET: False
2023-10-05 16:58:52,034 INFO Welcome to the CDS
2023-10-05 16:58:52,034 INFO Sending request to https://cds.climate.copernicus.eu/api/v2/resources/reanalysis-era5-land
2023-10-05 16:58:52,162 INFO Request is queued
2023-10-05 16:58:53,251 INFO Request is completed
2023-10-05 16:58:53,251 INFO Downloading https://download-0012-clone.copernicus-climate.eu/cache-compute-0012/cache/data0/adaptor.mars.internal-1696501013.798142-21806-11-09e10a51-2661-43a7-9100-13c4f5256cca.nc to ./cds_test.nc (27K)
2023-10-05 16:58:53,393 INFO Download rate 190.7K/s

QUIET: True

QUIET: False
2023-10-05 16:58:55,035 INFO Welcome to the CDS
2023-10-05 16:58:55,035 INFO Sending request to https://cds.climate.copernicus.eu/api/v2/resources/reanalysis-era5-land
2023-10-05 16:58:55,124 INFO Request is queued
2023-10-05 16:58:56,212 INFO Request is completed
2023-10-05 16:58:56,212 INFO Downloading https://download-0012-clone.copernicus-climate.eu/cache-compute-0012/cache/data0/adaptor.mars.internal-1696501013.798142-21806-11-09e10a51-2661-43a7-9100-13c4f5256cca.nc to ./cds_test.nc (27K)
2023-10-05 16:58:56,357 INFO Download rate 186.4K/s
```