### PR TITLE
Remove `verify: 0` from example config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,6 @@ and write it into the configuration file, so it looks like::
     $ cat ~/.cdsapirc
     url: https://cds.climate.copernicus.eu/api/v2
     key: <UID>:<API key>
-    verify: 0
 
 Remember to agree to the Terms and Conditions of every dataset that you intend to download.
 


### PR DESCRIPTION
This configuration option disables certificate verification, which should never be done. Having it be part of the example config in the readme makes it easy to accidentally copy and paste this dangerous configuration option.

Fixes #90.

I would go so far as to suggest to remove the option to disable certificate verification completely. There is basically no legitimate reason to do it. But that would be a larger change than this.