### PR TITLE
Update minimum version of cads-api-client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     include_package_data=True,
     install_requires=[
-        "cads-api-client>=0.9.2",
+        "cads-api-client>=1.2.0",
         "requests>=2.5.0",
         "tqdm",
     ],


### PR DESCRIPTION
The cads-api-client library's `Results` object has been updated at v1.2.0 to include a `location` property, which is required for `cdsapi` to work properly with downstream software packages like `earthkit-data`.

This PR updates the minimum version of cads-api-client to ensure `Results.location` exists.