### PR TITLE
Update to failing unit test

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,7 +21,8 @@ def test_request():
 
     r.download("test.grib")
 
-    assert os.path.getsize("test.grib") == 2076600
+    # Allow for minor changes due to differences in MARS client configuration
+    assert (os.path.getsize("test.grib") > 2076500) and (os.path.getsize("test.grib") < 2076700)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,7 +21,6 @@ def test_request():
 
     r.download("test.grib")
 
-    # Allow for minor changes due to differences in MARS client configuration
     assert os.path.getsize("test.grib") == 2076588
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,7 +22,9 @@ def test_request():
     r.download("test.grib")
 
     # Allow for minor changes due to differences in MARS client configuration
-    assert (os.path.getsize("test.grib") > 2076500) and (os.path.getsize("test.grib") < 2076700)
+    assert (os.path.getsize("test.grib") > 2076500) and (
+        os.path.getsize("test.grib") < 2076700
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,9 +22,7 @@ def test_request():
     r.download("test.grib")
 
     # Allow for minor changes due to differences in MARS client configuration
-    assert (os.path.getsize("test.grib") > 2076500) and (
-        os.path.getsize("test.grib") < 2076700
-    )
+    assert 2076500 < os.path.getsize("test.grib") < 2076700
 
 
 @pytest.mark.parametrize(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,7 +22,7 @@ def test_request():
     r.download("test.grib")
 
     # Allow for minor changes due to differences in MARS client configuration
-    assert 2076500 < os.path.getsize("test.grib") < 2076700
+    assert os.path.getsize("test.grib") == 2076588
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The test is failing without any changes to the cdsapi source code. Presumably due to hardware changes in the CDS resulting in minor changes to metadata. This PR ensures that the result is close in size to the expected result.

I have to say, I do not know how consistent we expect this file size to be, it seems to have been stable from 2018-2024, but recent changes to the way the CDS calls MARS are probably more significant than previous changes (i.e. through a proxy server layer).

Please see report from unmodified copy of the master branch that fails the unit test:
https://github.com/ecmwf/cdsapi/actions/runs/10214307701
