### PR TITLE
Commented the __new__ method of Client class to support the cds-beta in google-weather-tools.

### DIFF
--- a/cdsapi/api.py
+++ b/cdsapi/api.py
@@ -277,13 +277,13 @@ class Result(object):
 class Client(object):
     logger = logging.getLogger("cdsapi")
 
-    def __new__(cls, url=None, key=None, *args, **kwargs):
-        _, token, _ = get_url_key_verify(url, key, None)
-        if ":" in token:
-            return super().__new__(cls)
-        import cads_api_client.legacy_api_client
+    # def __new__(cls, url=None, key=None, *args, **kwargs):
+    #     _, token, _ = get_url_key_verify(url, key, None)
+    #     if ":" in token:
+    #         return super().__new__(cls)
+    #     import cads_api_client.legacy_api_client
 
-        return super().__new__(cads_api_client.legacy_api_client.LegacyApiClient)
+    #     return super().__new__(cads_api_client.legacy_api_client.LegacyApiClient)
 
     def __init__(
         self,


### PR DESCRIPTION
[google-weather-tools](https://github.com/google/weather-tools) use [cdsapi](https://cds.climate.copernicus.eu/) for downloading the data which will be deprecated on 16th september so for giving the support of the new [cds-beta](https://cds-beta.climate.copernicus.eu/) I updated the Client class of the current library as the **current code of this cdsapi library** is not compatible with this new cds-beta licenses.