### PR TITLE
Update Test in README.rst to reflect API changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Perform a small test retrieve of ERA5 data::
                "date": "2017-12-01/2017-12-31",
                "time": "12:00",
                "format": "grib"
-           }, 'download.grib')
+           }).download(target='download.grib')
     >>>
 
 


### PR DESCRIPTION
Including the target as the third argument in the cds.retrieve() method does not work with 0.7.2, returning the error:

AttributeError: 'str' object has no attribute 'download'

The included changes fix this issue, pointing the user to the appropriate syntax.