### PR TITLE
Change "Exception" to "ValueError"

### DIFF
--- a/cdsapi/api.py
+++ b/cdsapi/api.py
@@ -66,7 +66,7 @@ def get_url_key_verify(url, key, verify):
                 verify = bool(int(config.get("verify", 1)))
 
     if url is None or key is None or key is None:
-        raise Exception("Missing/incomplete configuration file: %s" % (dotrc))
+        raise ValueError("Missing/incomplete configuration file: %s" % (dotrc))
 
     # If verify is still None, then we set to default value of True
     if verify is None:


### PR DESCRIPTION
This PR changes the general "Exception" in api.py to ValueError.
From the python docs:
```
ValueError:
Raised when an operation or function receives an argument that has the right type but an inappropriate value, and the situation is not described by a more precise exception such as IndexError 
```
In general using "Exception" is a bit ambiguous and not recommended for production.