### PR TITLE
Add note on CDSAPI_RC env var to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,7 @@ and write it into the configuration file, so it looks like::
 
 Remember to agree to the Terms and Conditions of every dataset that you intend to download.
 
+To change the location of `~/.cdsapirc` set the `CDSAPI_RC` environment variable.
 
 Test
 ----


### PR DESCRIPTION
Added a note to the README.rst file about how to change the location of the `~/.cdsapirc` file.
